### PR TITLE
chore: added Figma install steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Programmatically generate Figma styles from JSON.
 
+## Installation
+
+- In the terminal, run `npm i && npm run webpack:watch`
+- Open Figma and select **Plugins** and click **Manage Plugins...**, which opens a modal
+- Click the **New** button in the modal that opens and select **Import plugin from manifest....**
+- Locate the `manifest.json` file in your local copy of this repo
+
 ## JSON Format
 
 ### Example


### PR DESCRIPTION
Adding install steps to the README doc to assist users who haven't installed a custom plugin to Figma before.